### PR TITLE
Restructure API's

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -26,6 +26,8 @@
     * [`POST /api/user/current`](#post-apiusercurrent)
     * [`POST /api/user/:id`](#post-apiuserid)
     * [`DELETE /api/user/:id`](#delete-apiuserid)
+  * [Miscellaneous](#miscellaneous)
+    * [`POST /api/signup`](#post-apisignup)
 
 <!-- tocstop -->
 
@@ -438,6 +440,26 @@ Delete a user.
 ##### Parameters
 
 URL parameter `id` indicates ID of mailing list to delete.
+
+##### Response
+
+Returns success message.
+
+### Miscellaneous
+
+#### `POST /api/signup`
+
+Signup for an event (or rather a list of shifts)
+
+##### Parameters
+
+Form data as `application/x-www-form-urlencoded`:
+
+```ts
+{
+  shifts: number[]; // List of shift IDs to sign up for
+}
+```
 
 ##### Response
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -20,6 +20,12 @@
     * [`GET /api/mailing-list`](#get-apimailing-list)
     * [`POST /api/mailing-list/:id`](#post-apimailing-listid)
     * [`DELETE /api/mailing-list/:id`](#delete-apimailing-listid)
+  * [`/api/user`: User management endpoints](#apiuser-user-management-endpoints)
+    * [`GET /api/user`](#get-apiuser)
+    * [`GET /api/user/current`](#get-apiusercurrent)
+    * [`POST /api/user/current`](#post-apiusercurrent)
+    * [`POST /api/user/:id`](#post-apiuserid)
+    * [`DELETE /api/user/:id`](#delete-apiuserid)
 
 <!-- tocstop -->
 
@@ -276,7 +282,7 @@ None
 
 #### `POST /api/mailing-list/:id`
 
-Update an event or its shift's details.
+Update a mailing list's details.
 
 ##### Parameters
 
@@ -298,6 +304,136 @@ Returns success message.
 #### `DELETE /api/mailing-list/:id`
 
 Delete a mailing list.
+
+##### Parameters
+
+URL parameter `id` indicates ID of mailing list to delete.
+
+##### Response
+
+Returns success message.
+
+### `/api/user`: User management endpoints
+
+#### `GET /api/user`
+
+Retrieve data on all users.
+
+##### Parameters
+
+None.
+
+##### Response
+
+#### `GET /api/user/current`
+
+Retrieve data on the current user
+
+##### Parameters
+
+None.
+
+##### Response
+
+```ts
+{
+  status: "success",
+  data: {
+    user: { // User details
+      first_name: string, // Real first name
+      last_name: string, // Real last name
+      email: string, // Email address
+      phone_1: string, // Primary contact number
+      phone_2: string, // Secondary contact number
+      role_id: number, // 1 = Volunteer, 2 = Organizer, 3 = Executive
+      title: string, // For execs, e.g. "Chair"
+      bio: string // For execs, blurb on exec page
+    },
+    userShifts: Array<{
+      user_shift_id: number, // Signup ID
+      hours: string, // Calculated or overwritten number of hours
+      confirmLevel: { // Status (signup, complete, ditched, etc.)
+        id: number, // Level ID (id > 0 = positive, id < 0 = negative)
+        name: string, // Human-readable ID (e.g. "Complete")
+        description: string // Human-readable description (e.g. "This shift has been recorded and completed")
+      },
+      shift: { // Shift details
+        shift_id: number, // Shift ID
+        shift_num: number, // Shift # (e.g. "Shift 2")
+        start_time: string, // Shift start time in ISO format
+        end_time: string, // Shift end time in ISO format
+        meals: string[], // Provided food (e.g. ['lunch', 'dinner'])
+        notes: string, // Shift notes
+      },
+      parentEvent: { // Event which shift belongs to
+        event_id: number, // Event ID
+        name: number // Event name
+      }
+    }>,
+    new: boolean // New user flag
+  }
+}
+```
+
+#### `POST /api/user/current`
+
+Update the current user's details
+
+##### Parameters
+
+Form data as `application/x-www-form-urlencoded`:
+
+```ts
+{
+  first_name: string, // Name
+  last_name: string, // Name
+  phone_1: string, // Primary phone number
+  phone_2: string, // Secondary phone number
+  mail_lists: Array<{ // List of subscribed mailing lists
+    mail_list_id: number // ID of mailing list
+  }>,
+  title: string, // For execs only, title
+  bio: string // For execs only, bio blurb
+}
+```
+
+##### Response
+
+Returns success message.
+
+#### `POST /api/user/:id`
+
+Update a user's details.
+
+##### Parameters
+
+URL parameter `id` indicates ID of event to update.
+
+Form data as `application/x-www-form-urlencoded`:
+
+```ts
+{
+  first_name: string, // New first name
+  last_name: string, // New last name
+  email: string, // New email address
+  phone_1: string, // New primary phone number
+  phone_2: string, // New secondary phone number
+  mail_lists: Array<{ // List of subscribed mailing lists
+    mail_list_id: number // ID of mailing list
+  }>,
+  role_id: number, // New role
+  title: string, // For execs only, new title
+  bio: string // For execs only, new bio blurb
+}
+```
+
+##### Response
+
+Returns success message.
+
+#### `DELETE /api/user/:id`
+
+Delete a user.
 
 ##### Parameters
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,308 @@
+# Volunteering Peel API Documentation
+
+## Table of Contents
+
+<!-- toc -->
+
+* [Ideology + Structure](#ideology--structure)
+* [Endpoint Definitions](#endpoint-definitions)
+  * [`/api/public`: Public endpoints](#apipublic-public-endpoints)
+    * [`GET /api/public/faq`](#get-apipublicfaq)
+    * [`GET /api/public/event`](#get-apipublicevent)
+    * [`GET /api/public/execs`](#get-apipublicexecs)
+    * [`GET /api/public/sponsors`](#get-apipublicsponsors)
+    * [`POST /api/public/mailing-list/:id`](#post-apipublicmailing-listid)
+  * [`/api/event`: Event management endpoints](#apievent-event-management-endpoints)
+    * [`GET /api/event`](#get-apievent)
+    * [`POST /api/event/:id`](#post-apieventid)
+    * [`DELETE /api/event/:id`](#delete-apieventid)
+  * [`/api/mailing-list`: Mailing list management endpoints](#apimailing-list-mailing-list-management-endpoints)
+    * [`GET /api/mailing-list`](#get-apimailing-list)
+    * [`POST /api/mailing-list/:id`](#post-apimailing-listid)
+    * [`DELETE /api/mailing-list/:id`](#delete-apimailing-listid)
+
+<!-- tocstop -->
+
+## Ideology + Structure
+
+**Note: This is an incomplete set of documentation. Endpoints can and will change faster than docs will update**
+
+A few key points before we begin:
+
+* Endpoints use either a HTTP `GET`, `POST` or `DELETE` to access, update, or delete data, respectively.
+* Endpoints all require a `Authorization: Bearer` HTTP header, except for `/api/public/**`.
+  * The Bearer token is a JWT web token signed by Auth0 and containing the email address of the currently logged in user.
+* Source files are all in the `@api` (`/src/api`) directory
+  * Almost all endpoints are defined in `@api/api.ts`, but some are extracted to their own files.
+
+All endpoints will respond with a JSON output.
+A successful operation will output as follows:
+
+```ts
+{
+  status: "success",
+  data: any
+}
+```
+
+A failed operation will respond as follows:
+
+```ts
+{
+  status: "error",
+  error: string,
+  details: any
+}
+```
+
+## Endpoint Definitions
+
+The following definitions each have 3 parts:
+
+* A description of the endpoint
+* A definition of the parameters
+* A definition of the response (i.e. `response.data`)
+
+### `/api/public`: Public endpoints
+
+This section will cover all publicly available endpoints.
+These endpoints **do not** require a JWT authorization token.
+
+#### `GET /api/public/faq`
+
+Get FAQ's.
+
+##### Parameters
+
+None.
+
+##### Response
+
+```ts
+{
+  status: "success",
+  data: Array<{
+    question: string, // FAQ question
+    answer: string // FAQ response
+  }>
+}
+```
+
+#### `GET /api/public/event`
+
+Get a list of all events. See [`GET /api/event`](#get-apievent).
+
+##### Parameters
+
+None.
+
+##### Response
+
+See [`GET /api/event`](#get-apievent). There are two differences though:
+
+* `data[].active` will not be set.
+* `data[].shift.signed_up` will always be `false`, as no signup state can be determined without login.
+
+#### `GET /api/public/execs`
+
+Get a list of current executives.
+
+##### Parameters
+
+None.
+
+##### Response
+
+```ts
+{
+  status: "success",
+  data: Array<{
+    user_id: number,
+    first_name: string,
+    last_name: string,
+    title: string,
+    bio: string // Biography/about blurb
+  }>
+}
+```
+
+#### `GET /api/public/sponsors`
+
+Get a list of sponsors.
+
+##### Parameters
+
+None.
+
+##### Response
+
+```ts
+{
+  status: "success",
+  data: Array<{
+    name: string, // Name
+    image: string, // URI of image to show
+    website: string // Website to direct to
+  }>
+}
+```
+
+#### `POST /api/public/mailing-list/:id`
+
+Add an email to a mailing list.
+
+##### Parameters
+
+URL parameter `id` indicates the ID of the mailing list to add to
+
+Form data as `application/x-www-form-urlencoded`:
+
+```ts
+{
+  email: string, // Email to add
+}
+```
+
+##### Response
+
+Returns success message.
+
+### `/api/event`: Event management endpoints
+
+#### `GET /api/event`
+
+##### Parameters
+
+None
+
+##### Response
+
+```ts
+{
+  status: "success",
+  data: Array<{
+    event_id: number, // Event ID
+    name: string, // Event name
+    address: string, // Event location
+    transport: string, // If not null and not empty, pickup/dropoff location
+    description: string, // Event description
+    active: boolean, // Whether or not to show event on /events page
+    shifts: Array<{ // Event shifts
+      shift_id: number, // Shift ID. Do not confuse with shift #
+      shift_num: number, // Shift # (i.e. Shift 1, Shift 2)
+      start_time: string, // ISO start time
+      end_time: string, // ISO end time
+      hours: string, // Duration in form HH:MM:SS
+      meals: Array<string>, // Provided food
+      max_spots: number, // Maximum spots available
+      spots_taken: number, // People signed up already
+      notes: string, // Shift description/notes
+      signed_up: boolean // Signed up status (will always be false)
+    }>
+  }>
+}
+```
+
+#### `POST /api/event/:id`
+
+Update an event or its shift's details.
+
+##### Parameters
+
+URL parameter `id` indicates ID of event to update.
+
+Form data as `application/x-www-form-urlencoded`:
+
+```ts
+{
+  name: string, // New event name
+  description: string, // New event description
+  address: string, // New event location
+  transport: string, // New event pickup location (or null for no transport)
+  active: boolean, // Show event on /events?
+  shifts: Array<{ // Data of new shifts
+    shift_id: number, // Old shift ID
+    shift_num: number, // New shift # (i.e. Shift 1, Shift 2)
+    start_time: string, // New ISO start time
+    end_time: string, // New ISO end time
+    meals: Array<string>, // New provided food
+    max_spots: number, // New maximum spots
+  }>,
+  deleteShifts: Array<number> // ID's of shifts that were removed
+}
+```
+
+##### Response
+
+Returns success message.
+
+#### `DELETE /api/event/:id`
+
+Delete an event.
+
+##### Parameters
+
+URL parameter `id` indicates ID of event to delete.
+
+##### Response
+
+Returns success message.
+
+### `/api/mailing-list`: Mailing list management endpoints
+
+#### `GET /api/mailing-list`
+
+##### Parameters
+
+None
+
+##### Response
+
+```ts
+{
+  status: "success",
+  data: Array<{
+    mail_list_id: number, // Numeric ID
+    display_name: string, // Short human-readable name
+    description: string, // Short(ish) description
+    members: Array<{ // Emails on list
+      first_name: string, // Name if provided, otherwise null
+      last_name: string, // Name if provided, otherwise null
+      email: string, // Email address
+    }>,
+  }>
+}
+```
+
+#### `POST /api/mailing-list/:id`
+
+Update an event or its shift's details.
+
+##### Parameters
+
+URL parameter `id` indicates ID of event to update.
+
+Form data as `application/x-www-form-urlencoded`:
+
+```ts
+{
+  display_name: string, // New display name
+  description: string // New description
+}
+```
+
+##### Response
+
+Returns success message.
+
+#### `DELETE /api/mailing-list/:id`
+
+Delete a mailing list.
+
+##### Parameters
+
+URL parameter `id` indicates ID of mailing list to delete.
+
+##### Response
+
+Returns success message.

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -89,53 +89,50 @@ api.delete('/user/:id', UserAPI.deleteUser);
 api.get('/user/current', UserAPI.getCurrentUser);
 
 // Get user shifts (but formatted)
-api.get('/attendance', (req, res) => {
+api.get('/attendance', async (req, res) => {
   if (req.user.role_id < ROLE_EXECUTIVE) res.error(403, 'Unauthorized');
-  let db: mysql.PoolConnection;
-  pool
-    .getConnection()
-    .then(conn => {
-      db = conn;
-      // grab user's first and last name as well as vw_user_shift
-      return db.query(`
+
+  let err, db: mysql.PoolConnection;
+  [err, db] = await to(req.pool.getConnection());
+  if (err) return res.error(500, 'Error connecting to database', err, db);
+
+  // grab user's first and last name as well as vw_user_shift
+  let userShifts: any[]; // update typings at a later date
+  [err, userShifts] = await to(
+    db.query(`
         SELECT us.*, u.first_name, u.last_name
         FROM vw_user_shift us
         JOIN user u ON u.user_id = us.user_id
-      `);
-    })
-    .then((userShifts: any[]) => {
-      res.success(
-        _.map(userShifts, userShift => ({
-          user_shift_id: +userShift.user_shift_id,
-          confirmLevel: {
-            id: +userShift.confirm_level_id,
-            name: userShift.confirm_level,
-            description: userShift.confirm_description,
-          },
-          hours: userShift.hours,
-          shift: {
-            shift_id: +userShift.shift_id,
-            shift_num: +userShift.shift_num,
-            start_time: userShift.start_time,
-            end_time: userShift.end_time,
-          },
-          parentEvent: {
-            event_id: +userShift.event_id,
-            name: userShift.name,
-          },
-          user: {
-            user_id: +userShift.user_id,
-            first_name: userShift.first_name,
-            last_name: userShift.last_name,
-          },
-        })),
-      );
-      db.release();
-    })
-    .catch(error => {
-      res.error(500, 'Database error', error);
-      if (db && db.end) db.release();
-    });
+      `),
+  );
+  if (err) return res.error(500, 'Error retreiving attendance', err, db);
+
+  res.success(
+    _.map(userShifts, userShift => ({
+      user_shift_id: +userShift.user_shift_id,
+      confirmLevel: {
+        id: +userShift.confirm_level_id,
+        name: userShift.confirm_level,
+        description: userShift.confirm_description,
+      },
+      hours: userShift.hours,
+      shift: {
+        shift_id: +userShift.shift_id,
+        shift_num: +userShift.shift_num,
+        start_time: userShift.start_time,
+        end_time: userShift.end_time,
+      },
+      parentEvent: {
+        event_id: +userShift.event_id,
+        name: userShift.name,
+      },
+      user: {
+        user_id: +userShift.user_id,
+        first_name: userShift.first_name,
+        last_name: userShift.last_name,
+      },
+    })),
+  );
 });
 
 // Get all mailing lists

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -226,12 +226,12 @@ const eventQuery = async (req: Express.Request, res: Express.Response, authorize
 };
 
 // Endpoint requires JWT (i.e. logged in)
-api.get('/events', (req, res) => eventQuery(req, res, true));
+api.get('/event', (req, res) => eventQuery(req, res, true));
 // Endpoint doesn't require JWT (i.e. not logged in)
-api.get('/public/events', (req, res) => eventQuery(req, res, false));
+api.get('/public/event', (req, res) => eventQuery(req, res, false));
 
 // Edit event
-api.post('/events/:id', async (req, res) => {
+api.post('/event/:id', async (req, res) => {
   if (req.user.role_id < ROLE_EXECUTIVE) res.error(403, 'Unauthorized');
 
   const { name, description, transport, address, active, shifts, deleteShifts } = req.body;
@@ -300,7 +300,7 @@ api.post('/events/:id', async (req, res) => {
 });
 
 // Delete event
-api.delete('/events/:id', async (req, res) => {
+api.delete('/event/:id', async (req, res) => {
   if (req.user.role_id < ROLE_EXECUTIVE) res.error(403, 'Unauthorized');
 
   let err, affectedRows;

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -8,6 +8,7 @@ import * as _ from 'lodash';
 import * as mysql from 'promise-mysql';
 
 // Import sub-APIs
+import * as EventAPI from '@api/event';
 import * as MailingListAPI from '@api/mailing-list';
 import * as UserAPI from '@api/user';
 
@@ -172,144 +173,14 @@ api.get('/public/sponsors', async (req, res) => {
   res.success(sponsors, 200);
 });
 
-// Events
-const eventQuery = async (req: Express.Request, res: Express.Response, authorized: boolean) => {
-  // Grab all events
-  let err, events;
-  [err, events] = await to(
-    req.db.query('SELECT event_id, name, address, transport, description, active FROM event'),
-  );
-  if (err) return res.error(500, 'Error retrieving event data', err);
-
-  // Get shifts for each event
-  const withShifts = await Promise.all(
-    _.map(events, async (event: VPEvent) => {
-      // If logged in, also check if user is already signed up
-      const query = authorized
-        ? // Query if logged in
-          `SELECT
-          s.shift_id, s.shift_num,
-          s.start_time, s.end_time, s.hours,
-          s.meals, s.max_spots, s.spots_taken, s.notes,
-          (CASE WHEN us.user_id IS NULL THEN 0 ELSE 1 END) AS signed_up
-        FROM vw_shift s
-        JOIN user u
-        LEFT JOIN user_shift us ON us.shift_id = s.shift_id AND us.user_id = u.user_id
-        WHERE s.event_id = ? AND u.email = ?`
-        : // Query if not logged in
-          `SELECT
-          s.shift_id, s.shift_num,
-          s.start_time, s.end_time, s.hours,
-          s.meals, s.max_spots, s.spots_taken, s.notes,
-          0 signed_up
-        FROM vw_shift s
-        WHERE s.event_id = ? AND ?`;
-      const userID = authorized ? req.user.email : -1; // Use -1 if logged out, as -1 will not match any users
-
-      let shifts;
-      [err, shifts] = await to(req.db.query(query, [event.event_id, userID]));
-      if (err) return res.error(500, 'Error retrieving shift data', err);
-
-      return {
-        ...event,
-        active: !!event.active, // Convert to boolean
-        shifts: shifts.map((shift: any) => ({
-          ...shift,
-          meals: shift.meals.split(','),
-          signed_up: !!shift.signed_up, // Convert to boolean
-        })),
-      };
-    }),
-  );
-
-  res.success(withShifts, 200);
-};
-
-// Endpoint requires JWT (i.e. logged in)
-api.get('/event', (req, res) => eventQuery(req, res, true));
+// Prived/authorized by JWT endpoint
+api.get('/event', EventAPI.eventQuery(true));
 // Endpoint doesn't require JWT (i.e. not logged in)
-api.get('/public/event', (req, res) => eventQuery(req, res, false));
-
+api.get('/public/event', EventAPI.eventQuery(false));
 // Edit event
-api.post('/event/:id', async (req, res) => {
-  if (req.user.role_id < ROLE_EXECUTIVE) res.error(403, 'Unauthorized');
-
-  const { name, description, transport, address, active, shifts, deleteShifts } = req.body;
-  let err,
-    eventID = +req.params.id;
-
-  // Cast parameter to number, because numbers are a good
-  if (eventID === -1) {
-    // Add new event
-    [err, { insertId: eventID }] = await to(
-      req.db.query('INSERT INTO event SET ?', {
-        name,
-        description,
-        transport,
-        address,
-        active,
-      }),
-    );
-    if (err) return res.error(500, 'Error creating new event', err);
-  } else {
-    // Update event
-    [err] = await to(
-      req.db.query('UPDATE event SET ? WHERE event_id = ?', [
-        { name, description, transport, address, active },
-        req.params.id,
-      ]),
-    );
-    if (err) return res.error(500, 'Error updating event data', err);
-
-    // Delete each shift marked for deletion
-    _.forEach(deleteShifts as number[], async id => {
-      [err] = await to(req.db.query('DELETE FROM shift WHERE shift_id = ?', id));
-      if (err) return res.error(500, 'Error deleting shift', err);
-    });
-  }
-
-  // Create/update shifts (delete is above)
-  _.forEach(shifts as Shift[], async shift => {
-    const values = {
-      event_id: eventID,
-      shift_num: shift.shift_num,
-      max_spots: shift.max_spots,
-      start_time: shift.start_time,
-      end_time: shift.end_time,
-      meals: shift.meals.join(),
-      notes: shift.notes,
-    };
-    if (shift.shift_id === -1) {
-      // Create new shift
-      [err] = await to(req.db.query('INSERT INTO shift SET ?', values));
-      if (err) return res.error(500, 'Error creating shift', err);
-    } else {
-      // Update shift
-      let changedRows;
-      [err, { changedRows }] = await to(
-        req.db.query('UPDATE shift SET ? WHERE shift_id = ?', [values, shift.shift_id]),
-      );
-      if (err || changedRows !== 1) return res.error(500, 'Error updating shift', err);
-    }
-  });
-
-  res.success(
-    `Event ${eventID === -1 ? 'added' : 'updated'} successfully`,
-    eventID === -1 ? 201 : 200,
-  );
-});
-
+api.post('/event/:id', EventAPI.editEvent);
 // Delete event
-api.delete('/event/:id', async (req, res) => {
-  if (req.user.role_id < ROLE_EXECUTIVE) res.error(403, 'Unauthorized');
-
-  let err, affectedRows;
-  [err, { affectedRows }] = await to(
-    req.db.query('DELETE FROM event WHERE event_id = ?', [req.params.id]),
-  );
-  if (err || affectedRows !== 1) return res.error(500, 'Error deleting to database', err);
-  res.success('Event deleted successfully', 202);
-});
+api.delete('/event/:id', EventAPI.deleteEvent);
 
 // Signup
 api.post('/signup', async (req, res) => {

--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -1,0 +1,143 @@
+/* tslint:disable:no-console no-var-requires import-name */
+import to from '@lib/await-to-js';
+import * as Bluebird from 'bluebird';
+import * as Express from 'express';
+import * as _ from 'lodash';
+import * as mysql from 'promise-mysql';
+
+// API Imports
+import * as API from '@api/api';
+
+export const eventQuery = (authorized: boolean) => async (
+  req: Express.Request,
+  res: Express.Response,
+) => {
+  // Grab all events
+  let err, events;
+  [err, events] = await to(
+    req.db.query('SELECT event_id, name, address, transport, description, active FROM event'),
+  );
+  if (err) return res.error(500, 'Error retrieving event data', err);
+
+  // Get shifts for each event
+  const withShifts = await Promise.all(
+    _.map(events, async (event: VPEvent) => {
+      // If logged in, also check if user is already signed up
+      const query = authorized
+        ? // Query if logged in
+          `SELECT
+          s.shift_id, s.shift_num,
+          s.start_time, s.end_time, s.hours,
+          s.meals, s.max_spots, s.spots_taken, s.notes,
+          (CASE WHEN us.user_id IS NULL THEN 0 ELSE 1 END) AS signed_up
+        FROM vw_shift s
+        JOIN user u
+        LEFT JOIN user_shift us ON us.shift_id = s.shift_id AND us.user_id = u.user_id
+        WHERE s.event_id = ? AND u.email = ?`
+        : // Query if not logged in
+          `SELECT
+          s.shift_id, s.shift_num,
+          s.start_time, s.end_time, s.hours,
+          s.meals, s.max_spots, s.spots_taken, s.notes,
+          0 signed_up
+        FROM vw_shift s
+        WHERE s.event_id = ? AND ?`;
+      const userID = authorized ? req.user.email : -1; // Use -1 if logged out, as -1 will not match any users
+
+      let shifts;
+      [err, shifts] = await to(req.db.query(query, [event.event_id, userID]));
+      if (err) return res.error(500, 'Error retrieving shift data', err);
+
+      return {
+        ...event,
+        active: !!event.active, // Convert to boolean
+        shifts: shifts.map((shift: any) => ({
+          ...shift,
+          meals: shift.meals.split(','),
+          signed_up: !!shift.signed_up, // Convert to boolean
+        })),
+      };
+    }),
+  );
+
+  res.success(withShifts, 200);
+};
+
+export async function editEvent(req: Express.Request, res: Express.Response) {
+  if (req.user.role_id < API.ROLE_EXECUTIVE) res.error(403, 'Unauthorized');
+
+  const { name, description, transport, address, active, shifts, deleteShifts } = req.body;
+  let err,
+    eventID = +req.params.id;
+
+  // Cast parameter to number, because numbers are a good
+  if (eventID === -1) {
+    // Add new event
+    [err, { insertId: eventID }] = await to(
+      req.db.query('INSERT INTO event SET ?', {
+        name,
+        description,
+        transport,
+        address,
+        active,
+      }),
+    );
+    if (err) return res.error(500, 'Error creating new event', err);
+  } else {
+    // Update event
+    [err] = await to(
+      req.db.query('UPDATE event SET ? WHERE event_id = ?', [
+        { name, description, transport, address, active },
+        req.params.id,
+      ]),
+    );
+    if (err) return res.error(500, 'Error updating event data', err);
+
+    // Delete each shift marked for deletion
+    _.forEach(deleteShifts as number[], async id => {
+      [err] = await to(req.db.query('DELETE FROM shift WHERE shift_id = ?', id));
+      if (err) return res.error(500, 'Error deleting shift', err);
+    });
+  }
+
+  // Create/update shifts (delete is above)
+  _.forEach(shifts as Shift[], async shift => {
+    const values = {
+      event_id: eventID,
+      shift_num: shift.shift_num,
+      max_spots: shift.max_spots,
+      start_time: shift.start_time,
+      end_time: shift.end_time,
+      meals: shift.meals.join(),
+      notes: shift.notes,
+    };
+    if (shift.shift_id === -1) {
+      // Create new shift
+      [err] = await to(req.db.query('INSERT INTO shift SET ?', values));
+      if (err) return res.error(500, 'Error creating shift', err);
+    } else {
+      // Update shift
+      let changedRows;
+      [err, { changedRows }] = await to(
+        req.db.query('UPDATE shift SET ? WHERE shift_id = ?', [values, shift.shift_id]),
+      );
+      if (err || changedRows !== 1) return res.error(500, 'Error updating shift', err);
+    }
+  });
+
+  res.success(
+    `Event ${eventID === -1 ? 'added' : 'updated'} successfully`,
+    eventID === -1 ? 201 : 200,
+  );
+}
+
+export async function deleteEvent(req: Express.Request, res: Express.Response) {
+  if (req.user.role_id < API.ROLE_EXECUTIVE) res.error(403, 'Unauthorized');
+
+  let err, affectedRows;
+  [err, { affectedRows }] = await to(
+    req.db.query('DELETE FROM event WHERE event_id = ?', [req.params.id]),
+  );
+  if (err || affectedRows !== 1) return res.error(500, 'Error deleting to database', err);
+  res.success('Event deleted successfully', 202);
+}

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -221,13 +221,15 @@ export async function updateUserMailLists(
 ): Promise<any> {
   // update mail list data
   return db.query('DELETE FROM user_mail_list WHERE user_id = ?', id).then(() =>
-    mailLists.map(async list => {
-      if (list.subscribed) {
-        return db.query('INSERT INTO user_mail_list SET ?', {
-          user_id: id,
-          mail_list_id: list.mail_list_id,
-        });
-      }
-    }),
+    Promise.all(
+      mailLists.map(async list => {
+        if (list.subscribed) {
+          return db.query('INSERT INTO user_mail_list SET ?', {
+            user_id: id,
+            mail_list_id: list.mail_list_id,
+          });
+        }
+      }),
+    ),
   );
 }

--- a/src/app/admin/components/modules/EditEvent.tsx
+++ b/src/app/admin/components/modules/EditEvent.tsx
@@ -142,7 +142,7 @@ export default class EditEvent extends React.Component<EditEventProps, EditEvent
     Promise.resolve(this.props.loading(true))
       .then(() =>
         axios.post(
-          `/api/events/${this.props.originalEvent.event_id}`,
+          `/api/event/${this.props.originalEvent.event_id}`,
           {
             name,
             description,
@@ -179,7 +179,7 @@ export default class EditEvent extends React.Component<EditEventProps, EditEvent
   public handleDelete = () => {
     Promise.resolve(this.props.loading(true))
       .then(() =>
-        axios.delete(`/api/events/${this.props.originalEvent.event_id}`, {
+        axios.delete(`/api/event/${this.props.originalEvent.event_id}`, {
           headers: { Authorization: `Bearer ${localStorage.getItem('id_token')}` },
         }),
       )

--- a/src/app/admin/components/pages/Events.tsx
+++ b/src/app/admin/components/pages/Events.tsx
@@ -41,7 +41,7 @@ export default class Events extends React.Component<
   public refresh() {
     return Promise.resolve(this.props.loading(true))
       .then(() => {
-        return axios.get('/api/events', {
+        return axios.get('/api/event', {
           headers: { Authorization: `Bearer ${localStorage.getItem('id_token')}` },
         });
       })

--- a/src/app/admin/components/pages/MailingList.tsx
+++ b/src/app/admin/components/pages/MailingList.tsx
@@ -8,7 +8,7 @@ import { Form, Header, Message, TextArea } from 'semantic-ui-react';
 
 interface MailingListState {
   // tslint:disable-next-line:prefer-array-literal
-  lists: Array<MailList & { members: MailListMember[] }>;
+  lists: (MailList & { members: MailListMember[] })[];
   active: number;
   loading: boolean;
   message: Message;

--- a/src/app/public/components/pages/Events.tsx
+++ b/src/app/public/components/pages/Events.tsx
@@ -40,11 +40,11 @@ export default class Events extends React.Component<EventsProps, EventsState> {
     return Promise.resolve(this.props.loading(true))
       .then(() => {
         if (localStorage.getItem('id_token')) {
-          return axios.get('/api/events', {
+          return axios.get('/api/event', {
             headers: { Authorization: `Bearer ${localStorage.getItem('id_token')}` },
           });
         }
-        return axios.get('/api/public/events');
+        return axios.get('/api/public/event');
       })
       .then(res => {
         // Only show events that are marked as active in admin console

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -1,16 +1,17 @@
 // tslint:disable:no-namespace
 // Extend Express definitions
-import promiseMysql = require('promise-mysql');
+import * as Bluebird from 'bluebird';
+import * as mysql from 'promise-mysql';
 
 declare global {
   namespace Express {
     interface Response {
-      error(status: number, error: string, details?: any, db?: promiseMysql.PoolConnection): void;
-      success(success?: any, status?: number, db?: promiseMysql.PoolConnection): void;
+      error(status: number, error: string, details?: any, db?: mysql.PoolConnection): void;
+      success(success?: any, status?: number, db?: mysql.PoolConnection): void;
     }
 
     interface Request {
-      pool: promiseMysql.Pool;
+      db: mysql.PoolConnection;
     }
 
     interface SessionData {

--- a/tslint.json
+++ b/tslint.json
@@ -10,6 +10,7 @@
     "object-literal-sort-keys": [true, "match-declaration-order"],
     "no-submodule-imports": false,
     "no-implicit-dependencies": false,
-    "one-variable-per-declaration": false
+    "one-variable-per-declaration": false,
+    "array-type": [true, "array"]
   }
 }


### PR DESCRIPTION
The `api.ts` file is currently a disaster, clocking in at nearly 400 (previously pre-#39 nearly 700) lines.

- [x] Extract all API calls to separate files
- [x] Document API calls, either inline or in a `docs/API.md`
- [x] Optimize all API calls to use `async/await` instead of that horribly callback hell that currently exists
- [x] Wrap all API calls in a MySQL transaction
- [ ] Optimize SQL statements, if possible