### PR TITLE
feat(admin/Attendance): Admins can update attendance statuses

### DIFF
--- a/sql/000-schema.sql
+++ b/sql/000-schema.sql
@@ -84,6 +84,7 @@ create table if not exists user_shift (
   user_id           int           not null                        comment 'User ID',
   start_override    datetime                                      comment 'Start of shift (otherwise uses shift value)',
   end_override      datetime                                      comment 'End of shift (otherwise uses shift value)',
+  hours_override    time                                          comment 'Add/subtract hours (for penalties, etc.)',
   confirm_level_id  int           not null default 0              comment 'Status',
   foreign key fk_user_shift_shift (shift_id) references shift(shift_id) on update cascade on delete cascade,
   foreign key fk_user_shift_user (user_id) references user(user_id) on update cascade on delete cascade,

--- a/sql/002-views.sql
+++ b/sql/002-views.sql
@@ -51,6 +51,7 @@ select
   s.shift_num,
   ifnull(us.start_override, s.start_time) as start_time,
   ifnull(us.end_override, s.end_time) as end_time,
+  us.hours_override,
   addtime(
     timediff(
       ifnull(us.end_override, s.end_time),

--- a/sql/002-views.sql
+++ b/sql/002-views.sql
@@ -51,9 +51,12 @@ select
   s.shift_num,
   ifnull(us.start_override, s.start_time) as start_time,
   ifnull(us.end_override, s.end_time) as end_time,
-  timediff(
-    ifnull(us.end_override, s.end_time),
-	ifnull(us.start_override, s.start_time)
+  addtime(
+    timediff(
+      ifnull(us.end_override, s.end_time),
+      ifnull(us.start_override, s.start_time)
+    ),
+    ifnull(us.hours_override, "00:00:00")
   ) as hours,
   s.meals,
   s.notes,

--- a/sql/003-code.sql
+++ b/sql/003-code.sql
@@ -1,0 +1,16 @@
+delimiter $$
+
+drop trigger if exists user_shift_bu$$
+create trigger user_shift_bu before update
+  on user_shift
+    for each row begin
+		select start_time, end_time into @start_time, @end_time from shift where shift_id = new.shift_id;
+		if (new.start_override = @start_time) then
+			set new.start_override = null;
+		end if;
+        if (new.end_override = @end_time) then
+			set new.end_override = null;
+		end if;
+	end$$
+
+delimiter ;

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -116,14 +116,16 @@ api.get('/attendance', async (req, res) => {
   );
   if (err) return res.error(500, 'Error retreiving attendance', err);
 
-  res.success(
-    _.map(userShifts, userShift => ({
+  let confirmLevels: ConfirmLevel[];
+  [err, confirmLevels] = await to(
+    req.db.query('SELECT confirm_level_id as id, name, description FROM confirm_level'),
+  );
+  if (err) return res.error(500, 'Error retrieving attendance statuses', err);
+
+  res.success({
+    attendance: _.map(userShifts, userShift => ({
       user_shift_id: +userShift.user_shift_id,
-      confirmLevel: {
-        id: +userShift.confirm_level_id,
-        name: userShift.confirm_level,
-        description: userShift.confirm_description,
-      },
+      confirmLevel: +userShift.confirm_level_id,
       hours: userShift.hours,
       shift: {
         shift_id: +userShift.shift_id,
@@ -141,7 +143,8 @@ api.get('/attendance', async (req, res) => {
         last_name: userShift.last_name,
       },
     })),
-  );
+    levels: confirmLevels,
+  });
 });
 
 // Get all mailing lists

--- a/src/api/attendance.ts
+++ b/src/api/attendance.ts
@@ -1,0 +1,74 @@
+/* tslint:disable:no-console no-var-requires import-name */
+import to from '@lib/await-to-js';
+import * as Bluebird from 'bluebird';
+import * as Express from 'express';
+import * as _ from 'lodash';
+import * as mysql from 'promise-mysql';
+
+// API Imports
+import * as API from '@api/api';
+
+export async function getAttendance(req: Express.Request, res: Express.Response) {
+  if (req.user.role_id < API.ROLE_EXECUTIVE) res.error(403, 'Unauthorized');
+
+  // grab user's first and last name as well as vw_user_shift
+  let err, userShifts: any[]; // update typings at a later date
+  [err, userShifts] = await to(
+    req.db.query(`
+        SELECT us.*, u.first_name, u.last_name
+        FROM vw_user_shift us
+        JOIN user u ON u.user_id = us.user_id
+      `),
+  );
+  if (err) return res.error(500, 'Error retreiving attendance', err);
+
+  let confirmLevels: ConfirmLevel[];
+  [err, confirmLevels] = await to(
+    req.db.query('SELECT confirm_level_id as id, name, description FROM confirm_level'),
+  );
+  if (err) return res.error(500, 'Error retrieving attendance statuses', err);
+
+  res.success({
+    attendance: _.map(userShifts, userShift => ({
+      user_shift_id: +userShift.user_shift_id,
+      confirm_level_id: +userShift.confirm_level_id,
+      hours: userShift.hours,
+      shift: {
+        shift_id: +userShift.shift_id,
+        shift_num: +userShift.shift_num,
+        start_time: userShift.start_time,
+        end_time: userShift.end_time,
+      },
+      parentEvent: {
+        event_id: +userShift.event_id,
+        name: userShift.name,
+      },
+      user: {
+        user_id: +userShift.user_id,
+        first_name: userShift.first_name,
+        last_name: userShift.last_name,
+      },
+    })),
+    levels: confirmLevels,
+  });
+}
+
+export async function updateAttendance(req: Express.Request, res: Express.Response) {
+  if (req.user.role_id < API.ROLE_EXECUTIVE) res.error(403, 'Unauthorized');
+
+  let err;
+
+  // update an attendance entry for each one
+  _.forEach(req.body, async userShift => {
+    let affectedRows;
+    [err, { affectedRows }] = await to(
+      req.db.query('UPDATE user_shift SET confirm_level_id = ? WHERE user_shift_id = ?', [
+        userShift.confirm_level_id,
+        userShift.user_shift_id,
+      ]),
+    );
+    if (err || affectedRows !== 1) res.error(500, 'Error updating attendance entries');
+  });
+
+  res.success(`Attendance updated successfully`, 200);
+}

--- a/src/api/attendance.ts
+++ b/src/api/attendance.ts
@@ -34,6 +34,7 @@ export async function getAttendance(req: Express.Request, res: Express.Response)
       confirm_level_id: +userShift.confirm_level_id,
       start_time: userShift.start_time,
       end_time: userShift.end_time,
+      hours_override: userShift.hours_override,
       shift: {
         shift_id: +userShift.shift_id,
         shift_num: +userShift.shift_num,
@@ -66,6 +67,7 @@ export async function updateAttendance(req: Express.Request, res: Express.Respon
           confirm_level_id: userShift.confirm_level_id,
           start_override: userShift.start_override,
           end_override: userShift.end_override,
+          hours_override: userShift.hours_override,
         },
         userShift.user_shift_id,
       ]),

--- a/src/api/attendance.ts
+++ b/src/api/attendance.ts
@@ -32,12 +32,11 @@ export async function getAttendance(req: Express.Request, res: Express.Response)
     attendance: _.map(userShifts, userShift => ({
       user_shift_id: +userShift.user_shift_id,
       confirm_level_id: +userShift.confirm_level_id,
-      hours: userShift.hours,
+      start_time: userShift.start_time,
+      end_time: userShift.end_time,
       shift: {
         shift_id: +userShift.shift_id,
         shift_num: +userShift.shift_num,
-        start_time: userShift.start_time,
-        end_time: userShift.end_time,
       },
       parentEvent: {
         event_id: +userShift.event_id,

--- a/src/api/attendance.ts
+++ b/src/api/attendance.ts
@@ -61,8 +61,12 @@ export async function updateAttendance(req: Express.Request, res: Express.Respon
   _.forEach(req.body, async userShift => {
     let affectedRows;
     [err, { affectedRows }] = await to(
-      req.db.query('UPDATE user_shift SET confirm_level_id = ? WHERE user_shift_id = ?', [
-        userShift.confirm_level_id,
+      req.db.query('UPDATE user_shift SET ? WHERE user_shift_id = ?', [
+        {
+          confirm_level_id: userShift.confirm_level_id,
+          start_override: userShift.start_override,
+          end_override: userShift.end_override,
+        },
         userShift.user_shift_id,
       ]),
     );

--- a/src/app/admin/components/pages/Attendance.tsx
+++ b/src/app/admin/components/pages/Attendance.tsx
@@ -1,14 +1,10 @@
 // Library Imports
 import axios, { AxiosError } from 'axios';
 import { LocationDescriptor } from 'history';
+import update from 'immutability-helper'; // tslint:disable-line:import-name
 import * as _ from 'lodash';
 import * as React from 'react';
-import { RouteComponentProps } from 'react-router';
-import { Link, Route } from 'react-router-dom';
-import { Dropdown, Header, Segment, Table } from 'semantic-ui-react';
-
-// Controllers Imports
-import EditEvent from '@app/admin/controllers/modules/EditEvent';
+import { Dropdown, Form, Table } from 'semantic-ui-react';
 
 interface AttendanceProps {
   addMessage: (message: Message) => any;
@@ -20,11 +16,12 @@ interface AttendanceState {
   attendance: AttendanceEntry[];
   activeData: AttendanceEntry[];
   activeEntry: number;
+  confirmLevels: ConfirmLevel[];
 }
 
 interface AttendanceEntry {
   user_shift_id: number;
-  confirmLevel: ConfirmLevel;
+  confirmLevel: number;
   hours: string;
   shift: {
     shift_id: number;
@@ -41,6 +38,7 @@ interface AttendanceEntry {
     first_name: string;
     last_name: string;
   };
+  changed: boolean;
 }
 
 export default class Attendance extends React.Component<AttendanceProps, AttendanceState> {
@@ -49,6 +47,7 @@ export default class Attendance extends React.Component<AttendanceProps, Attenda
 
     this.state = {
       attendance: [],
+      confirmLevels: [],
       activeData: [],
       activeEntry: null,
     };
@@ -67,7 +66,8 @@ export default class Attendance extends React.Component<AttendanceProps, Attenda
       })
       .then(res => {
         this.setState({
-          attendance: res.data.data,
+          attendance: res.data.data.attendance,
+          confirmLevels: res.data.data.levels,
         });
         this.props.loading(false);
       })
@@ -80,8 +80,25 @@ export default class Attendance extends React.Component<AttendanceProps, Attenda
       });
   }
 
+  public handleUpdate(entry: number, field: string, value: any) {
+    this.setState(
+      update(this.state, {
+        activeData: {
+          [_.findIndex(this.state.activeData, __ => __.user_shift_id === entry)]: {
+            [field]: {
+              $set: value,
+            },
+            changed: {
+              $set: true,
+            },
+          },
+        },
+      }),
+    );
+  }
+
   public render() {
-    const dropdownOptions = _.map(
+    const shifts = _.map(
       // filtered[0] will be the first one in each shift
       _.groupBy(this.state.attendance, 'shift.shift_id'),
       filtered => ({
@@ -91,41 +108,66 @@ export default class Attendance extends React.Component<AttendanceProps, Attenda
       }),
     );
 
+    const statuses = _.map(this.state.confirmLevels, level => ({
+      key: level.id,
+      value: level.id,
+      text: level.name,
+    }));
+
     return (
-      <>
+      <Form>
         <Dropdown
           placeholder="Select Shift"
           fluid
           search
           selection
-          options={dropdownOptions}
+          options={shifts}
           value={this.state.activeEntry ? this.state.activeEntry : null}
           onChange={(e, { value }) =>
             this.setState({
               activeEntry: +value,
-              activeData: _.filter(this.state.attendance, ['shift.shift_id', +value]),
+              activeData: _.map(
+                _.filter(this.state.attendance, ['shift.shift_id', +value]),
+                // set changed to false by default
+                __ => ({ ...__, changed: false }),
+              ),
             })
           }
         />
         {this.state.activeEntry && (
-          <Table
-            compact
-            celled
-            headerRow={['Status', 'First Name', 'Last Name', 'Start', 'End']}
-            renderBodyRow={(entry: AttendanceEntry) => ({
-              key: entry.user_shift_id,
-              cells: [
-                entry.confirmLevel.name,
-                entry.user.first_name,
-                entry.user.last_name,
-                entry.shift.start_time,
-                entry.shift.end_time,
-              ],
-            })}
-            tableData={this.state.activeData}
-          />
+          <>
+            <Table
+              compact
+              celled
+              headerRow={['Status', 'First Name', 'Last Name', 'Start', 'End']}
+              renderBodyRow={(entry: AttendanceEntry) => ({
+                key: entry.user_shift_id,
+                cells: [
+                  <td>
+                    <Dropdown
+                      inline
+                      fluid
+                      search
+                      options={statuses}
+                      value={entry.confirmLevel}
+                      onChange={(e, { value }) =>
+                        this.handleUpdate(entry.user_shift_id, 'confirmLevel', value)
+                      }
+                    />
+                  </td>,
+                  entry.user.first_name,
+                  entry.user.last_name,
+                  entry.shift.start_time,
+                  entry.shift.end_time,
+                ],
+                warning: entry.changed,
+              })}
+              tableData={this.state.activeData}
+            />
+            <Form.Button type="submit">Save</Form.Button>
+          </>
         )}
-      </>
+      </Form>
     );
   }
 }

--- a/src/app/admin/components/pages/Attendance.tsx
+++ b/src/app/admin/components/pages/Attendance.tsx
@@ -171,7 +171,7 @@ export default class Attendance extends React.Component<AttendanceProps, Attenda
     }));
 
     return (
-      <Form>
+      <Form onSubmit={this.handleSubmit}>
         <Dropdown
           placeholder="Select Shift"
           fluid
@@ -234,19 +234,41 @@ export default class Attendance extends React.Component<AttendanceProps, Attenda
                       />
                     ),
                   },
-                  timeFormat(
-                    moment
-                      .duration(moment(entry.end_time).diff(entry.start_time))
-                      .add(entry.hours_override),
-                  ),
+                  {
+                    key: 'hours',
+                    content: (
+                      <>
+                        {timeFormat(moment.duration(moment(entry.end_time).diff(entry.start_time)))}{' '}
+                        +
+                        <Form.Input
+                          inline
+                          fluid
+                          type="text"
+                          size="mini"
+                          pattern="[0-9]+(:[0-9]{2})?"
+                          value={entry.hours_override}
+                          placeholder="00:00"
+                          onChange={(e, { value }) => {
+                            if (/^[0-9]+:?[0-9]{0,2}$/.test(value)) {
+                              e.currentTarget.setCustomValidity('');
+                              this.handleUpdate(entry.user_shift_id, 'hours_override', value);
+                            } else if (!value) {
+                              // set to '' if empty (because empty doesn't match regex)
+                              this.handleUpdate(entry.user_shift_id, 'hours_override', '');
+                            } else {
+                              e.currentTarget.setCustomValidity('Please type a duration hh:mm');
+                            }
+                          }}
+                        />
+                      </>
+                    ),
+                  },
                 ],
                 warning: entry.changed,
               })}
               tableData={this.state.activeData}
             />
-            <Form.Button type="submit" onClick={this.handleSubmit}>
-              Save
-            </Form.Button>
+            <Form.Button type="submit">Save</Form.Button>
           </>
         )}
       </Form>

--- a/src/app/admin/components/pages/Attendance.tsx
+++ b/src/app/admin/components/pages/Attendance.tsx
@@ -4,13 +4,14 @@ import * as Bluebird from 'bluebird';
 import { LocationDescriptor } from 'history';
 import update from 'immutability-helper'; // tslint:disable-line:import-name
 import * as _ from 'lodash';
+import * as moment from 'moment';
 import * as React from 'react';
 import 'react-widgets/dist/css/react-widgets.css';
 import * as DateTimePicker from 'react-widgets/lib/DateTimePicker';
 import { Dropdown, Form, Table } from 'semantic-ui-react';
 
 // App Imports
-import { formatDateForMySQL } from '@app/common/utilities';
+import { formatDateForMySQL, timeFormat } from '@app/common/utilities';
 
 interface AttendanceProps {
   addMessage: (message: Message) => any;
@@ -30,6 +31,7 @@ interface AttendanceEntry {
   confirm_level_id: number;
   start_time: string;
   end_time: string;
+  hours_override: string;
   shift: {
     shift_id: number;
     shift_num: number;
@@ -189,7 +191,7 @@ export default class Attendance extends React.Component<AttendanceProps, Attenda
             <Table
               compact
               celled
-              headerRow={['Status', 'First Name', 'Last Name', 'Start', 'End']}
+              headerRow={['Status', 'First Name', 'Last Name', 'Start', 'End', 'Hours']}
               renderBodyRow={(entry: AttendanceEntry) => ({
                 key: entry.user_shift_id,
                 cells: [
@@ -232,6 +234,7 @@ export default class Attendance extends React.Component<AttendanceProps, Attenda
                       />
                     ),
                   },
+                  timeFormat(moment.duration(moment(entry.end_time).diff(entry.start_time))),
                 ],
                 warning: entry.changed,
               })}

--- a/src/app/admin/components/pages/Attendance.tsx
+++ b/src/app/admin/components/pages/Attendance.tsx
@@ -130,6 +130,7 @@ export default class Attendance extends React.Component<AttendanceProps, Attenda
             confirm_level_id: __.confirm_level_id,
             start_override: formatDateForMySQL(new Date(__.start_time)),
             end_override: formatDateForMySQL(new Date(__.end_time)),
+            hours_override: __.hours_override,
           })),
           { headers: { Authorization: `Bearer ${localStorage.getItem('id_token')}` } },
         ),
@@ -245,11 +246,11 @@ export default class Attendance extends React.Component<AttendanceProps, Attenda
                           fluid
                           type="text"
                           size="mini"
-                          pattern="[0-9]+(:[0-9]{2})?"
+                          pattern="-?[0-9]+(:[0-9]{2})?(:[0-9]{2})?"
                           value={entry.hours_override}
                           placeholder="00:00"
                           onChange={(e, { value }) => {
-                            if (/^[0-9]+:?[0-9]{0,2}$/.test(value)) {
+                            if (/^-?[0-9]+:?[0-9]{0,2}:?[0-9]{0,2}?$/.test(value)) {
                               e.currentTarget.setCustomValidity('');
                               this.handleUpdate(entry.user_shift_id, 'hours_override', value);
                             } else if (!value) {
@@ -260,6 +261,12 @@ export default class Attendance extends React.Component<AttendanceProps, Attenda
                             }
                           }}
                         />
+                        ={' '}
+                        {timeFormat(
+                          moment
+                            .duration(moment(entry.end_time).diff(entry.start_time))
+                            .add(entry.hours_override),
+                        )}
                       </>
                     ),
                   },

--- a/src/app/admin/components/pages/Attendance.tsx
+++ b/src/app/admin/components/pages/Attendance.tsx
@@ -5,6 +5,8 @@ import { LocationDescriptor } from 'history';
 import update from 'immutability-helper'; // tslint:disable-line:import-name
 import * as _ from 'lodash';
 import * as React from 'react';
+import 'react-widgets/dist/css/react-widgets.css';
+import * as DateTimePicker from 'react-widgets/lib/DateTimePicker';
 import { Dropdown, Form, Table } from 'semantic-ui-react';
 
 interface AttendanceProps {
@@ -23,12 +25,11 @@ interface AttendanceState {
 interface AttendanceEntry {
   user_shift_id: number;
   confirm_level_id: number;
-  hours: string;
+  start_time: string;
+  end_time: string;
   shift: {
     shift_id: number;
     shift_num: number;
-    start_time: string;
-    end_time: string;
   };
   parentEvent: {
     event_id: number;
@@ -101,7 +102,7 @@ export default class Attendance extends React.Component<AttendanceProps, Attenda
     this.setState(
       update(this.state, {
         activeData: {
-          [_.findIndex(this.state.activeData, __ => __.user_shift_id === entry)]: {
+          [_.findIndex(this.state.activeData, ['user_shift_id', entry])]: {
             [field]: {
               $set: value,
             },
@@ -122,6 +123,8 @@ export default class Attendance extends React.Component<AttendanceProps, Attenda
           _.map(_.filter(this.state.activeData, 'changed'), __ => ({
             user_shift_id: __.user_shift_id,
             confirm_level_id: __.confirm_level_id,
+            start_override: __.start_time,
+            end_override: __.end_time,
           })),
           { headers: { Authorization: `Bearer ${localStorage.getItem('id_token')}` } },
         ),
@@ -204,8 +207,28 @@ export default class Attendance extends React.Component<AttendanceProps, Attenda
                   },
                   entry.user.first_name,
                   entry.user.last_name,
-                  entry.shift.start_time,
-                  entry.shift.end_time,
+                  {
+                    key: 'start_time',
+                    content: (
+                      <DateTimePicker
+                        value={new Date(entry.start_time)}
+                        onChange={value =>
+                          this.handleUpdate(entry.user_shift_id, 'start_time', value.toISOString())
+                        }
+                      />
+                    ),
+                  },
+                  {
+                    key: 'end_time',
+                    content: (
+                      <DateTimePicker
+                        value={new Date(entry.end_time)}
+                        onChange={value =>
+                          this.handleUpdate(entry.user_shift_id, 'end_time', value.toISOString())
+                        }
+                      />
+                    ),
+                  },
                 ],
                 warning: entry.changed,
               })}

--- a/src/app/admin/components/pages/Attendance.tsx
+++ b/src/app/admin/components/pages/Attendance.tsx
@@ -9,6 +9,9 @@ import 'react-widgets/dist/css/react-widgets.css';
 import * as DateTimePicker from 'react-widgets/lib/DateTimePicker';
 import { Dropdown, Form, Table } from 'semantic-ui-react';
 
+// App Imports
+import { formatDateForMySQL } from '@app/common/utilities';
+
 interface AttendanceProps {
   addMessage: (message: Message) => any;
   loading: (status: boolean) => any;
@@ -123,8 +126,8 @@ export default class Attendance extends React.Component<AttendanceProps, Attenda
           _.map(_.filter(this.state.activeData, 'changed'), __ => ({
             user_shift_id: __.user_shift_id,
             confirm_level_id: __.confirm_level_id,
-            start_override: __.start_time,
-            end_override: __.end_time,
+            start_override: formatDateForMySQL(new Date(__.start_time)),
+            end_override: formatDateForMySQL(new Date(__.end_time)),
           })),
           { headers: { Authorization: `Bearer ${localStorage.getItem('id_token')}` } },
         ),

--- a/src/app/admin/components/pages/Attendance.tsx
+++ b/src/app/admin/components/pages/Attendance.tsx
@@ -234,7 +234,11 @@ export default class Attendance extends React.Component<AttendanceProps, Attenda
                       />
                     ),
                   },
-                  timeFormat(moment.duration(moment(entry.end_time).diff(entry.start_time))),
+                  timeFormat(
+                    moment
+                      .duration(moment(entry.end_time).diff(entry.start_time))
+                      .add(entry.hours_override),
+                  ),
                 ],
                 warning: entry.changed,
               })}

--- a/src/app/admin/components/pages/Attendance.tsx
+++ b/src/app/admin/components/pages/Attendance.tsx
@@ -18,6 +18,7 @@ interface AttendanceProps {
 
 interface AttendanceState {
   attendance: AttendanceEntry[];
+  activeData: AttendanceEntry[];
   activeEntry: number;
 }
 
@@ -48,6 +49,7 @@ export default class Attendance extends React.Component<AttendanceProps, Attenda
 
     this.state = {
       attendance: [],
+      activeData: [],
       activeEntry: null,
     };
   }
@@ -98,7 +100,12 @@ export default class Attendance extends React.Component<AttendanceProps, Attenda
           selection
           options={dropdownOptions}
           value={this.state.activeEntry ? this.state.activeEntry : null}
-          onChange={(e, { value }) => this.setState({ activeEntry: +value })}
+          onChange={(e, { value }) =>
+            this.setState({
+              activeEntry: +value,
+              activeData: _.filter(this.state.attendance, ['shift.shift_id', +value]),
+            })
+          }
         />
         {this.state.activeEntry && (
           <Table
@@ -115,7 +122,7 @@ export default class Attendance extends React.Component<AttendanceProps, Attenda
                 entry.shift.end_time,
               ],
             })}
-            tableData={_.filter(this.state.attendance, ['shift.shift_id', this.state.activeEntry])}
+            tableData={this.state.activeData}
           />
         )}
       </>

--- a/src/app/common/utilities.ts
+++ b/src/app/common/utilities.ts
@@ -25,7 +25,7 @@ export function formatDateForMySQL(date: Date): string {
     pad(date.getMonth() + 1) + // month is off by 1 (i.e. Jan = 0)
     '-' +
     pad(date.getDate()) +
-    'T' +
+    ' ' +
     pad(date.getHours()) +
     ':' +
     pad(date.getMinutes()) +

--- a/src/app/common/utilities.ts
+++ b/src/app/common/utilities.ts
@@ -2,6 +2,7 @@
 import { AxiosError, AxiosResponse } from 'axios';
 import * as Promise from 'bluebird';
 import { createBrowserHistory } from 'history';
+import * as moment from 'moment';
 import { routerMiddleware, routerReducer } from 'react-router-redux';
 import { applyMiddleware, combineReducers, compose, createStore, Dispatch, Store } from 'redux';
 import reduxThunk from 'redux-thunk';
@@ -17,8 +18,15 @@ import {
 } from '@app/common/actions';
 import * as reducers from '@app/common/reducers';
 
+// take a number and pad it with one zero if it needs to be (i.e. 1 => 01, 11 => 11, 123 => 123)
+const pad = (number: number) => (number < 10 ? ('00' + number).slice(-2) : number.toString());
+
+// moment duration toString basically (hh:mm)
+export function timeFormat(time: moment.Duration) {
+  return `${pad(Math.floor(time.asHours()))}:${pad(time.minutes())}`;
+}
+
 export function formatDateForMySQL(date: Date): string {
-  const pad = (num: number) => `0${num}`.substr(-2); // add leading 0
   return (
     date.getFullYear() +
     '-' +

--- a/src/app/public/components/pages/UserDashboard.tsx
+++ b/src/app/public/components/pages/UserDashboard.tsx
@@ -14,15 +14,13 @@ import {
   Table,
 } from 'semantic-ui-react';
 
+// App Imports
+import { timeFormat } from '@app/common/utilities';
+
 interface UserDashboardProps {
   user: UserState;
   loading: boolean;
 }
-
-// take a number and pad it with one zero if it needs to be (i.e. 1 => 01, 11 => 11, 123 => 123)
-const pad = (number: number) => (number < 10 ? ('00' + number).slice(-2) : number.toString());
-const timeFormat = (time: moment.Duration) =>
-  `${pad(Math.floor(time.asHours()))}:${pad(time.minutes())}`;
 
 export default class UserDashboard extends React.Component<UserDashboardProps> {
   public render() {


### PR DESCRIPTION
Implement UI/API for updating the status of an attendance (`user_shift`) entry.

- [x] Update attendance statuses (i.e. close #9)
- [x] Modify start/end overrides 
- [x] Manually set hour overrides (for penalties and whatnot, i.e. close #29)