### PR TITLE
fix(admin/Attendance): sort generated pdf case insensitively

### DIFF
--- a/src/app/admin/components/pages/Attendance.tsx
+++ b/src/app/admin/components/pages/Attendance.tsx
@@ -492,7 +492,7 @@ export default class Attendance extends React.Component<AttendanceProps, Attenda
                               noWrap: true,
                             })),
                             // body rows
-                            ..._.map(_.sortBy(this.state.attendance, 'user.first_name'), entry => [
+                            ..._.map(_.sortBy(this.state.attendance, entry => entry.user.first_name.toLowerCase()), entry => [
                               entry.user.first_name,
                               entry.user.last_name,
                               entry.user.phone_1 || '',


### PR DESCRIPTION
When user generates a pdf of the attendance, it now sorts through alphabetical order, *without* looking at the case.