### PR TITLE
add exec apps to events page

### DIFF
--- a/src/app/public/components/pages/Events.tsx
+++ b/src/app/public/components/pages/Events.tsx
@@ -10,6 +10,7 @@ import { Button, Container, Header, Item, Segment } from 'semantic-ui-react';
 
 // Component Imports
 import ProgressColor from '@app/public/components/blocks/ProgressColor';
+import HomepageMessage from '@app/public/components/modules/HomepageMessage';
 import SubscribeBox from '@app/public/components/modules/SubscribeBox';
 
 // Controller Imports
@@ -61,6 +62,7 @@ export default class Events extends React.Component<EventsProps, EventsState> {
   public render() {
     return (
       <>
+        <HomepageMessage />
         <Segment style={{ padding: '4em 0em' }} vertical>
           <Container textAlign="center">
             <Header as="h3">Event Notification Sign Up</Header>


### PR DESCRIPTION
Some volunteers ignore the home page and go straight to events, so this will help gain a better audience.